### PR TITLE
Add README to describe the blogging process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Posts
+
+This repo contains all of our blog content in Markdown format. Why? Becuase
+we're not exactly sure where it's all going to live and it's nice to keep
+everything in one place no matter where it gets published.
+
+We can also use a familiar workflow to write, edit and submit content -- Pull
+Requests!
+
+## How to submit
+
+1. Fork the repo.
+1. Create a branch.
+1. Create the post and write write write. Commit often.
+1. Ready? Fetch and rebase interactively against origin. Your new post should
+   be a single commit.
+1. Submit a pull request.
+
+## Editing
+
+1. The blog editor (currently @joelturnbull) will review and suggest edits to
+   grammar, spelling, etc. This might go back and forth a couple times.
+1. Once we're all happy, it'll be merged.
+
+## Posting
+
+Currently, we're publishing to tumblr.
+
+1. Make sure you've [enabled the Markdown editor in your tumblr
+   settings](https://www.tumblr.com/settings).
+2. Copy/paste your new post on tumblr.
+3. Save as draft.
+
+


### PR DESCRIPTION
We're all opinionated as to how we'd each like to blog. That's great, but we need to adopt a process so that we're all on the same page as to how to get content on the Gaslight blog. We'll document that here. As we make changes, we need to keep this document up to date. It is the canonical source for blogging at Gaslight.

This is my attempt at documenting the process. Let's see how this goes and make changes as necessary. It's entirely possible that we switch blogging engines, but let's make a list of things we want out of the new solution before we do that.

[Here's the README in HTML for reading](https://github.com/gaslight/posts/blob/dd2f876979cc415294522decc7d3201b547c93c7/README.md).
